### PR TITLE
Added kovan HLP_XSGD_USDC address

### DIFF
--- a/markets/halo/index.ts
+++ b/markets/halo/index.ts
@@ -65,6 +65,7 @@ export const HaloConfig: IHaloConfiguration = {
       XSGD: kovan.tokens.XSGD!,
       FXPHP: kovan.tokens.fxPHP!,
       HLPPHP: '0xEb06cF1cD90d75eC6d10bbdc43B555483674F6ff',
+      HLP_XSGD_USDC: kovan.lendingMarket!.lpAssets.HLP_XSGD_USDC!,
     },
     [eEthereumNetwork.ropsten]: {},
     [eEthereumNetwork.main]: {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "external:halo:deploy-assets-main": "npm run compile && hardhat --network main external:deploy-new-asset-halo --symbol ${SYMBOL} --verify"
   },
   "devDependencies": {
+    "@halodao/halodao-contract-addresses": "^0.0.29",
     "@nomiclabs/buidler": "^1.4.7",
     "@nomiclabs/buidler-ethers": "2.0.0",
     "@nomiclabs/buidler-etherscan": "^2.1.0",
@@ -173,7 +174,6 @@
   ],
   "license": "AGPLv3",
   "dependencies": {
-    "@halodao/halodao-contract-addresses": "^0.0.27",
     "axios-curlirize": "^1.3.7",
     "tmp-promise": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,10 +531,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@halodao/halodao-contract-addresses@^0.0.27":
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/@halodao/halodao-contract-addresses/-/halodao-contract-addresses-0.0.27.tgz#b32eddd992e1f88737f5b3ed8ca17b1757f36139"
-  integrity sha512-NKMqKa8amonPACxTIBtK0dfdoOBC7zBRN36ArM370vKrdAzWdn955JUKllqjXEDQrtPwzXUDnsXgb2rKBeuCUg==
+"@halodao/halodao-contract-addresses@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@halodao/halodao-contract-addresses/-/halodao-contract-addresses-0.0.29.tgz#0542b3af7880d57c3af947cea164482c20b64e6d"
+  integrity sha512-OQjNlItj8hoGERDpE2WzHakxp6yp5JOZ0wPZRAlYNTQ6ZXQysWEDqTLqnH7hAAT+ovnVEQDj02qOw0e4xRiY9w==
 
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
- added `HLP_XSGD_USDC` kovan address (prerequisite for adding this new asset)
- updated `@halodao/halodao-contract-addresses` to `0.0.29` which contains HLP_XSGD_USDC curve & price feed oracle address